### PR TITLE
Replace deprecated slice_unchecked

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -390,7 +390,7 @@ impl<A: Array<Item=u8>> SmallString<A> {
 
         while idx < len {
             let ch = unsafe {
-                self.slice_unchecked(idx, len).chars().next().unwrap()
+                self.get_unchecked(idx..len).chars().next().unwrap()
             };
 
             let ch_len = ch.len_utf8();


### PR DESCRIPTION
The compiler says `.slice_unchecked(begin, end)` is now deprecated in favor of `.get_unchecked(begin..end)`.