### PR TITLE
Add `std` feature, disabled by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,23 @@ jobs:
     - name: Test
       run: cargo test --verbose
 
-    - name: Build with features
-      run: cargo build --verbose --features ffi,serde
+    - name: Build with std
+      run: cargo build --verbose --features std,ffi
 
-    - name: Test with features
-      run: cargo test --verbose --features ffi,serde
+    - name: Test with std
+      run: cargo build --verbose --features std,ffi
+
+    - name: Build with serde/no_std
+      run: cargo build --verbose --features serde
+
+    - name: Test with serde/no_std
+      run: cargo test --verbose --features serde
+
+    - name: Build with serde/std
+      run: cargo build --verbose --features serde,std
+
+    - name: Test with serde/std
+      run: cargo test --verbose --features serde,std
 
     - name: Build with union feature
       if: matrix.platform.rust == 'nightly'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ readme = "README.md"
 
 [features]
 ffi = []
+std = ["serde/std"]
 union = ["smallvec/union"]
 
 [dependencies]
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
 smallvec = { version = "1.1" }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! ## `no_std` support
 //!
-//! By default, `smallstr` does not depend on `std`. However, the `ffi` feature will add
-//! `std` as a dependency.
+//! By default, `smallstr` does not depend on `std`. The `std` feature may be enabled
+//! to add the `std` dependency. The `ffi` feature also implies `std`.
 //!
 //! ## `ffi` feature
 //!
@@ -23,18 +23,18 @@
 //!
 //! This feature is disabled by default.
 //!
+//! By default, the `serde` dependency is compiled with `no_std`.
+//! If the `std` feature is enabled, `std` is added as a dependency in `serde`, as well.
+//!
 //! ## `union` feature
 //!
 //! This feature will enable the `union` feature in `smallvec`, which reduces the size of
 //! a `SmallString` instance. This feature requires a nightly compiler.
 
-#![no_std]
+#![cfg_attr(not(any(feature = "ffi", feature = "std")), no_std)]
 #![deny(missing_docs)]
 
 extern crate alloc;
-
-#[cfg(any(feature = "error", feature = "ffi",))]
-extern crate std;
 
 pub use string::*;
 


### PR DESCRIPTION
* Fixes `std` being included with `serde`

Fixes #6