### PR TITLE
bump smallvec version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ union = ["smallvec/union"]
 
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
-smallvec = { version = "1.1" }
+smallvec = { version = "1.8.0" }
 
 [dev-dependencies]
 bincode = "1.0"


### PR DESCRIPTION
It seems that previous versions of `smallvec` didn't have a proper support for `no_std`. Specifically, when `serde` feature is enabled it linked to `std` through `smallvec` because `smallvec` didn't have `default-features = false` for `serde`. This is blocking the use of this crate in `no_std` environments.