### PR TITLE
Document that the 'union' feature requires Rust 1.49, rather than nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //! ## `union` feature
 //!
 //! This feature will enable the `union` feature in `smallvec`, which reduces the size of
-//! a `SmallString` instance. This feature requires a nightly compiler.
+//! a `SmallString` instance. This feature requires Rust 1.49 or newer.
 
 #![cfg_attr(not(any(feature = "ffi", feature = "std")), no_std)]
 #![deny(missing_docs)]


### PR DESCRIPTION
The `union` feature of `smallvec` is available as of stable Rust 1.49, and no longer requires `nightly`.
The [smallvec](https://docs.rs/smallvec/latest/smallvec/#union) documentation correctly lists this requirement.
